### PR TITLE
include COPYING in source distributions too

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include COPYING


### PR DESCRIPTION
https://github.com/althonos/fs.sshfs/commit/0ddb2683853e4dad9c3ed015979169a5b6480c34 addressed https://github.com/althonos/fs.sshfs/issues/5 for wheel files, but the `COPYING` file still isn't included in the `tar.gz` files created by `sdist`. For that you, annoyingly, need a different change to `MANIFEST.in`.