### PR TITLE
fix for threading issue

### DIFF
--- a/fs/sshfs/sshfs.py
+++ b/fs/sshfs/sshfs.py
@@ -205,7 +205,8 @@ class SSHFS(FS):
             elif self.isdir(_path):
                 raise errors.FileExpected(path)
             with convert_sshfs_errors('openbin', path):
-                handle = self._sftp.open(
+                _sftp = self._client.open_sftp()
+                handle = _sftp.open(
                     _path,
                     mode=_mode.to_platform_bin(),
                     bufsize=buffering


### PR DESCRIPTION
The multi-threaded copy does the `open` in the main thread, but the reading / writing in a worker thread. I figured that paramiko's approach to thread-safety might be a little naive and assumes that a file is read from the same thread that opened it. Possibly it stores open files in a threading.tlocal.

This change opens a new sftp connection for each open file, which allows the tests to pass. 

I suspect this will have a minor impact on performance when opening files, hopefully outweighed by the benefits of the worker copy. An alternative would be to set `thread_safe` to `False` (which will be respected in the next version).