### PR TITLE
Allow passing arbitrary arguments to paramiko

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,8 +134,10 @@ with each argument explained below:
 ``config_path``
   the path to an OpenSSH configuration file.
 
-Once created, the ``SSHFS`` filesystem behaves like any other filesystem
-(see the `Pyfilesystem2 documentation <https://pyfilesystem2.readthedocs.io>`_).
+Additional keyword arguments will be passed to the underlying connection call,
+taking precedence over implicitly derived arguments.  Once created, the
+``SSHFS`` filesystem behaves like any other filesystem (see the `Pyfilesystem2
+documentation <https://pyfilesystem2.readthedocs.io>`_).
 
 Configuration
 -------------

--- a/fs/sshfs/sshfs.py
+++ b/fs/sshfs/sshfs.py
@@ -80,7 +80,7 @@ class SSHFS(FS):
 
     def __init__(self, host, user=None, passwd=None, pkey=None, timeout=10,
                  port=22, keepalive=10, compress=False,
-                 config_path='~/.ssh/config'):  # noqa: D102
+                 config_path='~/.ssh/config', **kwargs):  # noqa: D102
         super(SSHFS, self).__init__()
 
         # Attempt to get a configuration for the given host
@@ -97,15 +97,22 @@ class SSHFS(FS):
         self._timeout = timeout
 
         try:
-
             # TODO: add more options
             client.load_system_host_keys()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            argdict = {
+                "pkey": pkey,
+                "key_filename": keyfile,
+                "look_for_keys": True if (pkey and keyfile) is None else False,
+                "compress": compress,
+                "timeout": timeout
+            }
+
+            argdict.update(kwargs)
+
             client.connect(
                 socket.gethostbyname(host), port, user, passwd,
-                pkey=pkey, key_filename=keyfile,
-                look_for_keys=True if (pkey and keyfile) is None else False,
-                compress=compress, timeout=timeout
+                **argdict
             )
 
             if keepalive > 0:


### PR DESCRIPTION
Allows passing arbitrary keyword arguments to paramiko's connect call. 
The `SSHFS` constructor takes `**kwargs` and updates the argument dictionary, which is used to invoke the connect function.

Closes #22 