### PR TITLE
Add pool of SFTPClient sessions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           #- pypy-3.7
     steps:
     - name: Checkout SSH docker container
-      run: docker pull sjourdan/alpine-sshd
+      run: docker pull linuxserver/openssh-server
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 

--- a/fs/sshfs/pool.py
+++ b/fs/sshfs/pool.py
@@ -1,36 +1,36 @@
 
 import contextlib
 from queue import Queue
-from threading import RLock, local
+from threading import local
 from paramiko import SSHClient, SFTPClient
 
 _local = local()
 
 class ConnectionPool(object):
 
-    def __init__(self, open_func, close_func, healty_func, max_connections=4, timeout=None):
+    def __init__(self, open_func, max_connections=4, timeout=None):
         """
         A generic connection pool.
 
         :param open_func: Function that opens a new connection.
-        :param close_func: Function that closes a given connection.
-        :param healty_func: Function to check if an active connection is still healty.
         :param max_connections: Maximum number of open connections
         :param timeout: Maximum time to wait for a connection
         """
 
         self._open_func = open_func
-        self._close_func = close_func
-        self._healthy = healty_func
         self.timeout = timeout
-        self._lock = RLock()
-        # self.unused_timeout = unused_timeout :param unused_timeout: Time after which an unused connection should be closed
 
-        self.active = 0
         self._q = Queue(maxsize=max_connections)
+
+        while not self._q.full():
+            self._q.put(None)
 
     @contextlib.contextmanager
     def connection(self):
+        '''
+        Returns a ContextManager with an open connection.
+        This function returns the same connection when called recursively.
+        '''
         if getattr(_local, "conn", None) is None:
             try:
                 _local.conn = self.acquire()
@@ -41,27 +41,9 @@ class ConnectionPool(object):
         else:
             yield _local.conn
 
-
-    def _open(self):
-        self.active += 1
-        return self._open_func()
-
-    def _close(self, conn):
-        self.active -= 1
-        self._close_func(conn)
-
     def acquire(self):
-        while True:
-            with self._lock:
-                if self._q.empty() and self.active < self._q.maxsize:
-                    return self._open()
-            
-            conn = self._q.get(timeout=self.timeout)
-            if not self._healthy(conn):
-                self._close()
-                continue
-                
-            return conn
+        conn = self._q.get(timeout=self.timeout)
+        return self._open_func(conn)
 
     def release(self, conn):
         self._q.put(conn, block=False)
@@ -69,28 +51,25 @@ class ConnectionPool(object):
 class SFTPClientPool(ConnectionPool):
 
     def __init__(self, client:SSHClient, max_connections:int=4, timeout=None):
-        
-        def open_sftp():
-            return client.open_sftp()
-        
-        def close_sftp(sftp:SFTPClient):
-            sftp.close()
+        """
+        A pool of SFTPClient sessions
 
-        def is_healthy(sftp:SFTPClient) -> bool:
-            return not sftp.get_channel().closed
+        :param max_connections: Maximum number of open sessions
+        :param timeout: Maximum time to wait for a session
+        """
+
+        def open_sftp(conn: SFTPClient | None):
+            if conn is None or conn.get_channel().closed:
+                return client.open_sftp()
+            return conn
         
-        super().__init__(open_sftp, close_sftp, is_healthy, max_connections, timeout)
+        super().__init__(open_sftp, max_connections, timeout)
 
     def acquire(self) -> SFTPClient:
-        conn: SFTPClient = super().acquire()
-        channel = conn.get_channel()
-        transport = channel.get_transport()
-
-        if channel.closed:
-            raise Exception("Channel is closed")
-        
-        if not transport.is_active():
-            raise Exception("Transport is closed")
-
-        return conn
+        """
+        Acquire an SFTPClient.
+        If timeout is None this functions blocks until a free session is available.
+        Otherwise an Empty exception is raised.
+        """
+        return super().acquire()
 

--- a/fs/sshfs/pool.py
+++ b/fs/sshfs/pool.py
@@ -1,0 +1,96 @@
+
+import contextlib
+from queue import Queue
+from threading import RLock, local
+from paramiko import SSHClient, SFTPClient
+
+_local = local()
+
+class ConnectionPool(object):
+
+    def __init__(self, open_func, close_func, healty_func, max_connections=4, timeout=None):
+        """
+        A generic connection pool.
+
+        :param open_func: Function that opens a new connection.
+        :param close_func: Function that closes a given connection.
+        :param healty_func: Function to check if an active connection is still healty.
+        :param max_connections: Maximum number of open connections
+        :param timeout: Maximum time to wait for a connection
+        """
+
+        self._open_func = open_func
+        self._close_func = close_func
+        self._healthy = healty_func
+        self.timeout = timeout
+        self._lock = RLock()
+        # self.unused_timeout = unused_timeout :param unused_timeout: Time after which an unused connection should be closed
+
+        self.active = 0
+        self._q = Queue(maxsize=max_connections)
+
+    @contextlib.contextmanager
+    def connection(self):
+        if getattr(_local, "conn", None) is None:
+            try:
+                _local.conn = self.acquire()
+                yield _local.conn
+            finally:
+                self.release(_local.conn)
+                _local.conn = None
+        else:
+            yield _local.conn
+
+
+    def _open(self):
+        self.active += 1
+        return self._open_func()
+
+    def _close(self, conn):
+        self.active -= 1
+        self._close_func(conn)
+
+    def acquire(self):
+        while True:
+            with self._lock:
+                if self._q.empty() and self.active < self._q.maxsize:
+                    return self._open()
+            
+            conn = self._q.get(timeout=self.timeout)
+            if not self._healthy(conn):
+                self._close()
+                continue
+                
+            return conn
+
+    def release(self, conn):
+        self._q.put(conn, block=False)
+
+class SFTPClientPool(ConnectionPool):
+
+    def __init__(self, client:SSHClient, max_connections:int=4, timeout=None):
+        
+        def open_sftp():
+            return client.open_sftp()
+        
+        def close_sftp(sftp:SFTPClient):
+            sftp.close()
+
+        def is_healthy(sftp:SFTPClient) -> bool:
+            return not sftp.get_channel().closed
+        
+        super().__init__(open_sftp, close_sftp, is_healthy, max_connections, timeout)
+
+    def acquire(self) -> SFTPClient:
+        conn: SFTPClient = super().acquire()
+        channel = conn.get_channel()
+        transport = channel.get_transport()
+
+        if channel.closed:
+            raise Exception("Channel is closed")
+        
+        if not transport.is_active():
+            raise Exception("Transport is closed")
+
+        return conn
+

--- a/fs/sshfs/sshfs.py
+++ b/fs/sshfs/sshfs.py
@@ -292,7 +292,7 @@ class SSHFS(FS):
             # preserve times if required
             if preserve_time:
                 self._utime(
-                    _path,
+                    _dst_path,
                     src_info.raw["details"]["modified"],
                     src_info.raw["details"]["accessed"],
                 )

--- a/fs/sshfs/sshfs.py
+++ b/fs/sshfs/sshfs.py
@@ -61,7 +61,7 @@ class SSHFS(FS):
             `paramiko.AutoAddPolicy` instance.
         max_connections (int): Maximum number of concurrent SFTPClient sessions
             (defaults to 4)
-        conn_timeout (int): The maximum time to wait for a free session. 
+        conn_timeout (float): The maximum time to wait for a free session. 
             Defaults to the value of ``timeout``.
 
     Raises:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 codecov ~=2.1
-docker ~=4.4
+docker ~=7.1.0
 urllib3 <2
 semantic-version ~=2.6
 mock ~=3.0.5  ; python_version < '3.3'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 codecov ~=2.1
-docker ~=7.1.0
+docker ~=6.1.3
+requests ==2.31.0 # https://github.com/docker/docker-py/issues/3256
 urllib3 <2
 semantic-version ~=2.6
 mock ~=3.0.5  ; python_version < '3.3'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,8 +29,8 @@ def fs_version():
 
 def startServer(docker_client, user, pasw, port):
     sftp_container = docker_client.containers.run(
-        "sjourdan/alpine-sshd", detach=True, ports={'22/tcp': port},
-        environment={'USER': user, 'PASSWORD': pasw},
+        "lscr.io/linuxserver/openssh-server", detach=True, ports={'2222/tcp': port},
+        environment={'USER_NAME': user, 'USER_PASSWORD': pasw, "PASSWORD_ACCESS": "true"},
     )
     time.sleep(1)
     return sftp_container


### PR DESCRIPTION
This PR should make fs.sshfs thread safe. #17 

Changes:
  - Add `SFTPClientPool` - a pool of `SFTPClient` sessions to share across threads
  - New SSHFS arguments
    ```
    max_connections (int): Maximum number of concurrent SFTPClient sessions
            (defaults to 4)
    conn_timeout (float): The maximum time to wait for a free session. 
        Defaults to the value of ``timeout``.
    ``` 
- Use docker image `linuxserver/openssh-server` to run tests.
  I got the following error when I tried to pull `sjourdan/alpine-sshd`:
  ```
  [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/sjourdan/alpine-sshd:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
  ```
