### PR TITLE
Fix reopen sftp connection

### DIFF
--- a/fs/sshfs/sshfs.py
+++ b/fs/sshfs/sshfs.py
@@ -329,8 +329,7 @@ class SSHFS(FS):
             elif self.isdir(_path):
                 raise errors.FileExpected(path)
             with convert_sshfs_errors('openbin', path):
-                _sftp = self._client.open_sftp()
-                handle = _sftp.open(
+                handle = self._sftp.open(
                     _path,
                     mode=_mode.to_platform_bin(),
                     bufsize=buffering


### PR DESCRIPTION
Since this object, on the init method already initializes __sftp_ private attribute by opening the sftp connection, the execution of openbin() method and the re-openning of an sftp connections raises later Paramiko issues.

`h = SSHFS("host", user="user, passwd="pwd") `
`h.openbin("path/to/file")`